### PR TITLE
Add Sphinx documentation configured for Read the Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+docs/_build/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,19 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
+project = 'opseestools'
+author = 'opseestools contributors'
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+]
+
+autodoc_mock_imports = ['openseespy', 'matplotlib', 'numpy', 'scipy', 'pandas']
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,15 @@
+Welcome to opseestools's documentation!
+=======================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,22 @@
+opseestools package
+===================
+
+.. automodule:: opseestools.Lib_frag
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: opseestools.analisis
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: opseestools.analisis3D
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: opseestools.utilidades
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx-rtd-theme

--- a/opseestools/utilidades.py
+++ b/opseestools/utilidades.py
@@ -883,15 +883,25 @@ def dhakal(Fyy, Fuu, eyy, ehh, euu, Lb, Db):
     
     return s, e
 
-def residual_disp(drifts,npts):
-    ''' Calcula el drift residual de una estructura sometida a un terremoto
-        Recibe dos entradas:
-            drifts contiene los drifts a lo largo del sismo
-            npts es el número de puntos hasta donde llega el registro
-        
-        Este algoritmo requiere que se haya corrido un periodo de vibración libre luego del final del registro
-        
-    '''
+def residual_disp(drifts, npts):
+    """Calculates the residual drift of a structure after an earthquake.
+
+    Parameters
+    ----------
+    drifts : array-like
+        Drift values recorded during the seismic event.
+    npts : int
+        Number of points corresponding to the ground-motion duration.
+
+    Returns
+    -------
+    float
+        Mean absolute residual drift computed from the free-vibration response.
+
+    Notes
+    -----
+    This algorithm assumes a free-vibration period after the end of the record.
+    """
     freevib = drifts[npts:-1] # extrae los valores de drifts a partir de donde comenzó la vibración libre
     peaks_ind = argrelextrema(freevib, np.greater) # calcula los indices de los puntos de los máximos
     peaks_ind = peaks_ind[0]


### PR DESCRIPTION
## Summary
- Add Sphinx configuration and doc skeleton for autodoc
- Provide Read the Docs config and requirements for building docs
- Improve `residual_disp` docstring to build cleanly

## Testing
- `python -m sphinx -b html docs docs/_build/html`


------
https://chatgpt.com/codex/tasks/task_e_68a5cfdf93b0832eba72e2250fc6b1c2