### PR TITLE
Set up module-specific Sphinx pages for Read the Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+docs/_build/
+
+venv/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/Lib_frag.rst
+++ b/docs/Lib_frag.rst
@@ -1,0 +1,7 @@
+Lib_frag module
+===============
+
+.. automodule:: opseestools.Lib_frag
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/_static/.gitkeep
+++ b/docs/_static/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for static assets

--- a/docs/_templates/.gitkeep
+++ b/docs/_templates/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for custom templates

--- a/docs/analisis.rst
+++ b/docs/analisis.rst
@@ -1,0 +1,7 @@
+analisis module
+===============
+
+.. automodule:: opseestools.analisis
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/analisis3D.rst
+++ b/docs/analisis3D.rst
@@ -1,0 +1,7 @@
+analisis3D module
+=================
+
+.. automodule:: opseestools.analisis3D
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,19 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
+project = 'opseestools'
+author = 'opseestools contributors'
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+]
+
+autodoc_mock_imports = ['openseespy', 'matplotlib', 'numpy', 'scipy', 'pandas']
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,15 @@
+Welcome to opseestools's documentation!
+=======================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,10 @@
+opseestools package
+===================
+
+.. toctree::
+   :maxdepth: 1
+
+   utilidades
+   analisis
+   analisis3D
+   Lib_frag

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx-rtd-theme

--- a/docs/utilidades.rst
+++ b/docs/utilidades.rst
@@ -1,0 +1,7 @@
+utilidades module
+=================
+
+.. automodule:: opseestools.utilidades
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/opseestools/Lib_frag.py
+++ b/opseestools/Lib_frag.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Created on Wed Nov  1 15:34:48 2023
-
-@author: Dirsa
-"""
+"""Fragility curve fitting utilities."""
 #%%
 
 import numpy as np                                                              # Importa librería estándar para operaciones matematicas.

--- a/opseestools/analisis3D.py
+++ b/opseestools/analisis3D.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Created on Mon Mar 21 17:59:44 2022
-
-@author: Orlando
-"""
+"""3D structural analysis utilities."""
 from openseespy.opensees import *
 import matplotlib.pyplot as plt
 import numpy as np

--- a/opseestools/utilidades.py
+++ b/opseestools/utilidades.py
@@ -883,15 +883,25 @@ def dhakal(Fyy, Fuu, eyy, ehh, euu, Lb, Db):
     
     return s, e
 
-def residual_disp(drifts,npts):
-    ''' Calcula el drift residual de una estructura sometida a un terremoto
-        Recibe dos entradas:
-            drifts contiene los drifts a lo largo del sismo
-            npts es el número de puntos hasta donde llega el registro
-        
-        Este algoritmo requiere que se haya corrido un periodo de vibración libre luego del final del registro
-        
-    '''
+def residual_disp(drifts, npts):
+    """Calculates the residual drift of a structure after an earthquake.
+
+    Parameters
+    ----------
+    drifts : array-like
+        Drift values recorded during the seismic event.
+    npts : int
+        Number of points corresponding to the ground-motion duration.
+
+    Returns
+    -------
+    float
+        Mean absolute residual drift computed from the free-vibration response.
+
+    Notes
+    -----
+    This algorithm assumes a free-vibration period after the end of the record.
+    """
     freevib = drifts[npts:-1] # extrae los valores de drifts a partir de donde comenzó la vibración libre
     peaks_ind = argrelextrema(freevib, np.greater) # calcula los indices de los puntos de los máximos
     peaks_ind = peaks_ind[0]


### PR DESCRIPTION
## Summary
- expose each opseestools module on its own Sphinx page
- drop autogenerated header comments from 3D analysis and fragility modules

## Testing
- `python -m py_compile opseestools/utilidades.py opseestools/analisis.py opseestools/analisis3D.py opseestools/Lib_frag.py`
- `python -m sphinx -b html docs docs/_build/html`


------
https://chatgpt.com/codex/tasks/task_e_68a5cfdf93b0832eba72e2250fc6b1c2